### PR TITLE
feat: allow customization of the HttpTransferCache.

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -16,6 +16,7 @@ import {HttpHeaders} from './headers';
 import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
+import {ALLOWED_METHODS} from './transfer_cache';
 
 
 /**
@@ -138,6 +139,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<ArrayBuffer>;
 
   /**
@@ -159,6 +161,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<Blob>;
 
   /**
@@ -180,6 +183,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<string>;
 
   /**
@@ -202,6 +206,7 @@ export class HttpClient {
           observe: 'events',
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
   /**
@@ -223,6 +228,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
   /**
@@ -244,6 +250,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpEvent<string>>;
 
   /**
@@ -266,6 +273,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpEvent<any>>;
 
   /**
@@ -288,6 +296,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpEvent<R>>;
 
   /**
@@ -308,6 +317,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
   /**
@@ -327,6 +337,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
   /**
@@ -347,6 +358,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpResponse<string>>;
 
   /**
@@ -390,6 +402,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<HttpResponse<R>>;
 
   /**
@@ -412,6 +425,7 @@ export class HttpClient {
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<Object>;
 
   /**
@@ -434,6 +448,7 @@ export class HttpClient {
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<R>;
 
   /**
@@ -455,6 +470,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   }): Observable<any>;
 
   /**
@@ -493,6 +509,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   } = {}): Observable<any> {
     let req: HttpRequest<any>;
     // First, check whether the primary argument is an instance of `HttpRequest`.
@@ -523,6 +540,14 @@ export class HttpClient {
         }
       }
 
+      // Should we inject(Console) ?
+      if ((typeof ngDevMode === 'undefined' || ngDevMode) &&
+          options.skipHttpTransferCache !== undefined && !ALLOWED_METHODS.includes(first)) {
+        console.warn(
+            `This ${first} request to ${url} has the  \`skipHttpTransferCache\` option set, but ${
+                first} request are not cached.`);
+      }
+
       // Construct the request.
       req = new HttpRequest(first, url!, (options.body !== undefined ? options.body : null), {
         headers,
@@ -532,6 +557,7 @@ export class HttpClient {
         // By default, JSON is assumed to be returned for all calls.
         responseType: options.responseType || 'json',
         withCredentials: options.withCredentials,
+        skipHttpTransferCache: options.skipHttpTransferCache,
       });
     }
 
@@ -946,6 +972,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<ArrayBuffer>;
 
   /**
@@ -965,6 +992,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<Blob>;
 
   /**
@@ -984,6 +1012,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<string>;
 
   /**
@@ -1003,6 +1032,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpEvent<ArrayBuffer>>;
 
   /**
@@ -1021,6 +1051,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpEvent<Blob>>;
 
   /**
@@ -1039,6 +1070,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpEvent<string>>;
 
   /**
@@ -1058,6 +1090,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpEvent<Object>>;
 
   /**
@@ -1077,6 +1110,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpEvent<T>>;
 
   /**
@@ -1096,6 +1130,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpResponse<ArrayBuffer>>;
 
   /**
@@ -1115,6 +1150,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpResponse<Blob>>;
 
   /**
@@ -1134,6 +1170,7 @@ export class HttpClient {
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpResponse<string>>;
 
   /**
@@ -1154,6 +1191,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpResponse<Object>>;
 
   /**
@@ -1174,6 +1212,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<HttpResponse<T>>;
 
   /**
@@ -1195,6 +1234,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<Object>;
 
   /**
@@ -1215,6 +1255,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   }): Observable<T>;
 
   /**
@@ -1231,6 +1272,7 @@ export class HttpClient {
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean
   } = {}): Observable<any> {
     return this.request<any>('GET', url, options as any);
   }

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -23,6 +23,7 @@ interface HttpRequestInit {
   params?: HttpParams;
   responseType?: 'arraybuffer'|'blob'|'json'|'text';
   withCredentials?: boolean;
+  skipHttpTransferCache?: boolean;
 }
 
 /**
@@ -154,6 +155,13 @@ export class HttpRequest<T> {
    */
   readonly urlWithParams: string;
 
+  /**
+   * Exclude the request from the [Http Transfer
+   * Cache](/guide/universal#caching-data-when-using-httpclient)
+   */
+  readonly skipHttpTransferCache?: boolean;
+
+
   constructor(method: 'DELETE'|'GET'|'HEAD'|'JSONP'|'OPTIONS', url: string, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
@@ -161,6 +169,7 @@ export class HttpRequest<T> {
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   });
   constructor(method: 'POST'|'PUT'|'PATCH', url: string, body: T|null, init?: {
     headers?: HttpHeaders,
@@ -169,6 +178,7 @@ export class HttpRequest<T> {
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   });
   constructor(method: string, url: string, body: T|null, init?: {
     headers?: HttpHeaders,
@@ -177,6 +187,7 @@ export class HttpRequest<T> {
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
+    skipHttpTransferCache?: boolean,
   });
   constructor(
       method: string, readonly url: string, third?: T|{
@@ -186,6 +197,7 @@ export class HttpRequest<T> {
         params?: HttpParams,
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
         withCredentials?: boolean,
+        skipHttpTransferCache?: boolean,
       }|null,
       fourth?: {
         headers?: HttpHeaders,
@@ -194,6 +206,7 @@ export class HttpRequest<T> {
         params?: HttpParams,
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
         withCredentials?: boolean,
+        skipHttpTransferCache?: boolean,
       }) {
     this.method = method.toUpperCase();
     // Next, need to figure out which argument holds the HttpRequestInit
@@ -233,6 +246,10 @@ export class HttpRequest<T> {
 
       if (!!options.params) {
         this.params = options.params;
+      }
+
+      if (!!options.skipHttpTransferCache) {
+        this.skipHttpTransferCache = options.skipHttpTransferCache;
       }
     }
 

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES,} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {first, tap} from 'rxjs/operators';
 
@@ -24,22 +24,30 @@ interface TransferHttpResponse {
   responseType?: HttpRequest<unknown>['responseType'];
 }
 
-const CACHE_STATE = new InjectionToken<{isCacheActive: boolean}>(
-    ngDevMode ? 'HTTP_TRANSFER_STATE_CACHE_STATE' : '');
+interface CacheOptions {
+  isCacheActive: boolean;
+  exclude?: (req: HttpRequest<unknown>) => boolean;
+}
+
+const CACHE_OPTIONS =
+    new InjectionToken<CacheOptions>(ngDevMode ? 'HTTP_TRANSFER_STATE_CACHE_OPTIONS' : '');
 
 /**
  * A list of allowed HTTP methods to cache.
  */
-const ALLOWED_METHODS = ['GET', 'HEAD'];
+export const ALLOWED_METHODS = ['GET', 'HEAD'];
 
 export function transferCacheInterceptorFn(
     req: HttpRequest<unknown>, next: HttpHandlerFn): Observable<HttpEvent<unknown>> {
-  const {isCacheActive} = inject(CACHE_STATE);
+  const {isCacheActive, exclude} = inject(CACHE_OPTIONS);
+  const skipCacheForRequest =
+      exclude?.(req) || req.skipHttpTransferCache || !ALLOWED_METHODS.includes(req.method);
 
   // Stop using the cache if the application has stabilized, indicating initial rendering
   // is complete.
-  if (!isCacheActive || !ALLOWED_METHODS.includes(req.method)) {
-    // Cache is no longer active or method is not HEAD or GET.
+  if (!isCacheActive || skipCacheForRequest) {
+    // Cache is no longer active or method is not HEAD or GET
+    // or we explicitly want to skip the cache for this particular request
     // Pass the request through.
     return next(req);
   }
@@ -144,27 +152,28 @@ function generateHash(value: string): string {
  * load time.
  *
  */
-export function withHttpTransferCache(): Provider[] {
+export function withHttpTransferCache(
+    cacheOptions?: {exclude?: (req: HttpRequest<unknown>) => boolean;}): Provider[] {
   return [
     {
-      provide: CACHE_STATE,
-      useFactory: () => {
+      provide: CACHE_OPTIONS,
+      useFactory: (): CacheOptions => {
         inject(ENABLED_SSR_FEATURES).add('httpcache');
-        return {isCacheActive: true};
+        return {isCacheActive: true, exclude: cacheOptions?.exclude};
       }
     },
     {
       provide: HTTP_ROOT_INTERCEPTOR_FNS,
       useValue: transferCacheInterceptorFn,
       multi: true,
-      deps: [TransferState, CACHE_STATE]
+      deps: [TransferState, CACHE_OPTIONS]
     },
     {
       provide: APP_BOOTSTRAP_LISTENER,
       multi: true,
       useFactory: () => {
         const appRef = inject(ApplicationRef);
-        const cacheState = inject(CACHE_STATE);
+        const cacheState = inject(CACHE_OPTIONS);
 
         return () => {
           appRef.isStable.pipe(first((isStable) => isStable)).toPromise().then(() => {

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -25,8 +25,9 @@ describe('TransferCache', () => {
   describe('withHttpTransferCache', () => {
     let isStable: BehaviorSubject<boolean>;
 
-    function makeRequestAndExpectOne(url: string, body: string): void {
-      TestBed.inject(HttpClient).get(url).subscribe();
+    function makeRequestAndExpectOne(
+        url: string, body: string, options?: {skipHttpTransferCache?: boolean}): void {
+      TestBed.inject(HttpClient).get(url, options).subscribe();
       TestBed.inject(HttpTestingController).expectOne(url).flush(body);
     }
 
@@ -123,6 +124,16 @@ describe('TransferCache', () => {
       makeRequestAndExpectNone('/test-1?foo=1');
       await expectAsync(TestBed.inject(HttpClient).get('/test-1?foo=1').toPromise())
           .toBeResolvedTo('foo');
+    });
+
+    it('should skip cache when specified', () => {
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo', {skipHttpTransferCache: true});
+
+      // The previous request wasn't cached so this one can't use the cache
+      makeRequestAndExpectOne('/test-1?foo=1', 'foo');
+
+      // But this one will
+      makeRequestAndExpectNone('/test-1?foo=1');
     });
   });
 });

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -45,7 +45,7 @@
     "name": "BrowserXhr"
   },
   {
-    "name": "CACHE_STATE"
+    "name": "CACHE_OPTIONS"
   },
   {
     "name": "CIRCULAR"

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -78,7 +78,7 @@ export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 export {EVENT_MANAGER_PLUGINS, EventManager, EventManagerPlugin} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
-export {HydrationFeature, provideClientHydration, HydrationFeatureKind, withNoDomReuse, withNoHttpTransferCache} from './hydration';
+export {HydrationFeature, provideClientHydration, HydrationFeatureKind, withNoDomReuse, withHttpTransferCache} from './hydration';
 
 export * from './private_export';
 export {VERSION} from './version';

--- a/packages/platform-browser/test/hydration_spec.ts
+++ b/packages/platform-browser/test/hydration_spec.ts
@@ -14,20 +14,25 @@ import {TestBed} from '@angular/core/testing';
 import {withBody} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
 
-import {provideClientHydration, withNoHttpTransferCache} from '../public_api';
+import {provideClientHydration, withHttpTransferCache} from '../public_api';
 
 describe('provideClientHydration', () => {
   @Component({selector: 'test-hydrate-app', template: ''})
   class SomeComponent {
   }
 
-  function makeRequestAndExpectOne(url: string, body: string): void {
-    TestBed.inject(HttpClient).get(url).subscribe();
+  function makeRequestAndExpectOne(
+      url: string, body: string, options?: {skipHttpTransferCache: boolean}): void {
+    TestBed.inject(HttpClient)
+        .get(url, {skipHttpTransferCache: options?.skipHttpTransferCache})
+        .subscribe();
     TestBed.inject(HttpTestingController).expectOne(url).flush(body);
   }
 
-  function makeRequestAndExpectNone(url: string): void {
-    TestBed.inject(HttpClient).get(url).subscribe();
+  function makeRequestAndExpectNone(url: string, options?: {skipHttpTransferCache: true}): void {
+    TestBed.inject(HttpClient)
+        .get(url, {skipHttpTransferCache: options?.skipHttpTransferCache})
+        .subscribe();
     TestBed.inject(HttpTestingController).expectNone(url);
   }
 
@@ -63,7 +68,7 @@ describe('provideClientHydration', () => {
     });
   });
 
-  describe('withNoHttpTransferCache', () => {
+  describe('withHttpTransferCache', () => {
     beforeEach(withBody(
         `<!--${SSR_CONTENT_INTEGRITY_MARKER}--><test-hydrate-app></test-hydrate-app>`, () => {
           TestBed.resetTestingModule();
@@ -73,7 +78,7 @@ describe('provideClientHydration', () => {
             providers: [
               {provide: DOCUMENT, useFactory: () => document},
               {provide: ApplicationRef, useClass: ApplicationRefPatched},
-              provideClientHydration(withNoHttpTransferCache()),
+              provideClientHydration(withHttpTransferCache({disable: true})),
               provideHttpClient(),
               provideHttpClientTesting(),
             ],
@@ -83,10 +88,36 @@ describe('provideClientHydration', () => {
           appRef.bootstrap(SomeComponent);
         }));
 
-    it(`should not cached HTTP calls`, () => {
-      makeRequestAndExpectOne('/test-1', 'foo');
+    it(`should not cache HTTP calls with skipHttpTransferCache:true`, () => {
+      makeRequestAndExpectOne('/test-1', 'foo', {skipHttpTransferCache: true});
       // Do the same call, this time should pass through as cache is disabled.
       makeRequestAndExpectOne('/test-1', 'foo');
+    });
+
+    it('should not cache HTTP calls with skipHttpTransferCache', () => {
+      withBody(
+          `<!--${SSR_CONTENT_INTEGRITY_MARKER}--><test-hydrate-app></test-hydrate-app>`, () => {
+            TestBed.resetTestingModule();
+
+            TestBed.configureTestingModule({
+              declarations: [SomeComponent],
+              providers: [
+                {provide: DOCUMENT, useFactory: () => document},
+                {provide: ApplicationRef, useClass: ApplicationRefPatched},
+                provideClientHydration(withHttpTransferCache({disable: true})),
+                provideHttpClient(),
+                provideHttpClientTesting(),
+              ],
+            });
+
+            const appRef = TestBed.inject(ApplicationRef);
+            appRef.bootstrap(SomeComponent);
+
+            makeRequestAndExpectOne('/test-1', 'foo', {skipHttpTransferCache: true});
+
+            // Do the same call, this time should pass through as cache is disabled.
+            makeRequestAndExpectOne('/test-1', 'foo');
+          });
     });
   });
 });

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -11,11 +11,11 @@ import {animate, AnimationBuilder, state, style, transition, trigger} from '@ang
 import {DOCUMENT, isPlatformServer, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, EnvironmentProviders, getPlatform, HostListener, Inject, inject as coreInject, Injectable, Input, makeStateKey, mergeApplicationConfig, NgModule, NgZone, PLATFORM_ID, Provider, TransferState, Type, ViewEncapsulation} from '@angular/core';
+import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, EnvironmentProviders, HostListener, Inject, inject as coreInject, Injectable, Input, makeStateKey, mergeApplicationConfig, NgModule, NgZone, PLATFORM_ID, Provider, TransferState, Type, ViewEncapsulation} from '@angular/core';
 import {SSR_CONTENT_INTEGRITY_MARKER} from '@angular/core/src/hydration/utils';
 import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {TestBed} from '@angular/core/testing';
-import {bootstrapApplication, BrowserModule, provideClientHydration, Title, withNoDomReuse, withNoHttpTransferCache} from '@angular/platform-browser';
+import {bootstrapApplication, BrowserModule, provideClientHydration, Title, withHttpTransferCache, withNoDomReuse} from '@angular/platform-browser';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformServer, PlatformState, provideServerRendering, renderModule, ServerModule} from '@angular/platform-server';
 import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {Observable} from 'rxjs';
@@ -957,8 +957,8 @@ describe('platform-server integration', () => {
 
            const bootstrap = renderApplication(
                getStandaloneBoostrapFn(
-                   SimpleApp,
-                   [provideClientHydration(withNoDomReuse(), withNoHttpTransferCache())]),
+                   SimpleApp, [provideClientHydration(
+                                  withNoDomReuse(), withHttpTransferCache({disable: true}))]),
                {...options, platformProviders: providers});
            const output = await bootstrap;
            // All features were disabled, so none of them are included.


### PR DESCRIPTION
`withHttpTransferCacheOptions()` accepts a set of options to allow customization of the cache :
* `disable` replaces `withNoHttpTransferCache()`
*  `exclude`: a callback to determine wether a request should be cached or not

BREAKING CHANGE: `withNoHttpTransferCache` is replaced by `withHttpTransferCacheOptions({ disable: true })`

Fixes #...