### PR TITLE
refactor(http): create an `InjectionToken` for a global `HttpBackend`

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -190,6 +190,12 @@ export const HTTP_ROOT_INTERCEPTOR_FNS =
     new InjectionToken<readonly HttpInterceptorFn[]>(ngDevMode ? 'HTTP_ROOT_INTERCEPTOR_FNS' : '');
 
 /**
+ * A provider to set a global primary http backend. If set, it will override the default one
+ */
+export const PRIMARY_HTTP_BACKEND = new InjectionToken<HttpBackend>(ngDevMode ? 'PRIMARY_HTTP_BACKEND' : '');
+
+
+/**
  * Creates an `HttpInterceptorFn` which lazily initializes an interceptor chain from the legacy
  * class-based interceptors and runs the request through it.
  */
@@ -220,6 +226,9 @@ export class HttpInterceptorHandler extends HttpHandler {
 
   constructor(private backend: HttpBackend, private injector: EnvironmentInjector) {
     super();
+
+    const primaryHttpBackend = inject(PRIMARY_HTTP_BACKEND, {optional: true});
+    this.backend = primaryHttpBackend ?? backend;
   }
 
   override handle(initialRequest: HttpRequest<any>): Observable<HttpEvent<any>> {

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -11,7 +11,7 @@ import {EnvironmentProviders, inject, InjectionToken, makeEnvironmentProviders, 
 import {HttpBackend, HttpHandler} from './backend';
 import {HttpClient} from './client';
 import {FetchBackend} from './fetch';
-import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, HttpInterceptorHandler, legacyInterceptorFnFactory} from './interceptor';
+import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, HttpInterceptorHandler, legacyInterceptorFnFactory, PRIMARY_HTTP_BACKEND} from './interceptor';
 import {jsonpCallbackContext, JsonpCallbackContext, JsonpClientBackend, jsonpInterceptorFn} from './jsonp';
 import {HttpXhrBackend} from './xhr';
 import {HttpXsrfCookieExtractor, HttpXsrfTokenExtractor, XSRF_COOKIE_NAME, XSRF_ENABLED, XSRF_HEADER_NAME, xsrfInterceptorFn} from './xsrf';
@@ -261,5 +261,6 @@ export function withFetch(): HttpFeature<HttpFeatureKind.Fetch> {
   return makeHttpFeature(HttpFeatureKind.Fetch, [
     FetchBackend,
     {provide: HttpBackend, useExisting: FetchBackend},
+    {provide: PRIMARY_HTTP_BACKEND, useExisting: FetchBackend},
   ]);
 }

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -7,14 +7,14 @@
  */
 
 import {DOCUMENT, XhrFactory} from '@angular/common';
-import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, JsonpClientBackend} from '@angular/common/http';
+import {FetchBackend, HTTP_INTERCEPTORS, HttpBackend, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpXhrBackend, JsonpClientBackend} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
 import {createEnvironmentInjector, EnvironmentInjector, inject, InjectionToken, PLATFORM_ID, Provider} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {EMPTY, Observable} from 'rxjs';
 
 import {HttpInterceptorFn} from '../src/interceptor';
-import {provideHttpClient, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from '../src/provider';
+import {provideHttpClient, withFetch, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from '../src/provider';
 
 describe('provideHttp', () => {
   beforeEach(() => {
@@ -387,6 +387,32 @@ describe('provideHttp', () => {
       req.flush('');
     });
   });
+
+  describe('fetch support', () => {
+    it('withFetch', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withFetch())
+        ]
+      });
+      const fetchBackend = TestBed.inject(HttpBackend);
+      expect(fetchBackend).toBeInstanceOf(FetchBackend);
+    });
+
+    it('withFetch should always override the backend', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withFetch()),
+          {provide: HttpBackend, useClass: HttpXhrBackend},
+        ]
+      });
+
+      const handler = TestBed.inject(HttpHandler);
+      expect((handler as any).backend).toBeInstanceOf(FetchBackend);
+    });
+  })
 });
 
 function setXsrfToken(token: string): void {


### PR DESCRIPTION
`withHttp` provides the new `PRIMARY_HTTP_BACKEND` token with `FetchBackend` to use it globally.

This commit also promotes the `FetchBackend` to stable.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
