### PR TITLE
refactor(animations): move `BrowserAnimationBuilder` to the animation package

### DIFF
--- a/goldens/public-api/animations/browser/index.md
+++ b/goldens/public-api/animations/browser/index.md
@@ -4,8 +4,12 @@
 
 ```ts
 
+import { AnimationBuilder } from '@angular/animations';
+import { AnimationFactory } from '@angular/animations';
+import { AnimationMetadata } from '@angular/animations';
 import { AnimationPlayer } from '@angular/animations';
 import * as i0 from '@angular/core';
+import { RendererFactory2 } from '@angular/core';
 
 // @public (undocumented)
 export abstract class AnimationDriver {
@@ -26,6 +30,17 @@ export abstract class AnimationDriver {
     abstract validateAnimatableStyleProperty?: (prop: string) => boolean;
     // (undocumented)
     abstract validateStyleProperty(prop: string): boolean;
+}
+
+// @public (undocumented)
+export class BrowserAnimationBuilder extends AnimationBuilder {
+    constructor(rootRenderer: RendererFactory2, doc: Document);
+    // (undocumented)
+    build(animation: AnimationMetadata | AnimationMetadata[]): AnimationFactory;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<BrowserAnimationBuilder, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<BrowserAnimationBuilder>;
 }
 
 // @public

--- a/packages/animations/browser/BUILD.bazel
+++ b/packages/animations/browser/BUILD.bazel
@@ -14,6 +14,7 @@ ng_module(
     ),
     deps = [
         "//packages/animations",
+        "//packages/common",
         "//packages/core",
     ],
 )

--- a/packages/animations/browser/src/animation_builder.ts
+++ b/packages/animations/browser/src/animation_builder.ts
@@ -10,7 +10,10 @@ import type {ɵAnimationRenderer as AnimationRenderer} from '@angular/animations
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, RendererFactory2, RendererType2, ViewEncapsulation} from '@angular/core';
 
-@Injectable()
+/**
+ * @publicApi
+ */
+@Injectable({providedIn: 'root'})
 export class BrowserAnimationBuilder extends AnimationBuilder {
   private _nextAnimationId = 0;
   private _renderer: AnimationRenderer;

--- a/packages/animations/browser/src/browser.ts
+++ b/packages/animations/browser/src/browser.ts
@@ -11,5 +11,7 @@
  * @description
  * Entry point for all animation APIs of the animation browser package.
  */
+export {BrowserAnimationBuilder} from './animation_builder';
 export {AnimationDriver, NoopAnimationDriver} from './render/animation_driver';
+
 export * from './private_export';

--- a/packages/platform-browser/animations/src/private_export.ts
+++ b/packages/platform-browser/animations/src/private_export.ts
@@ -6,5 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {BrowserAnimationBuilder as ɵBrowserAnimationBuilder} from './animation_builder';
 export {InjectableAnimationEngine as ɵInjectableAnimationEngine} from './providers';

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -6,13 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationBuilder} from '@angular/animations';
-import {AnimationDriver, NoopAnimationDriver, ɵAnimationEngine as AnimationEngine, ɵAnimationRendererFactory as AnimationRendererFactory, ɵAnimationStyleNormalizer as AnimationStyleNormalizer, ɵWebAnimationsDriver as WebAnimationsDriver, ɵWebAnimationsStyleNormalizer as WebAnimationsStyleNormalizer} from '@angular/animations/browser';
+import {AnimationBuilder,} from '@angular/animations';
+import {AnimationDriver, BrowserAnimationBuilder, NoopAnimationDriver, ɵAnimationEngine as AnimationEngine, ɵAnimationRendererFactory as AnimationRendererFactory, ɵAnimationStyleNormalizer as AnimationStyleNormalizer, ɵWebAnimationsDriver as WebAnimationsDriver, ɵWebAnimationsStyleNormalizer as WebAnimationsStyleNormalizer} from '@angular/animations/browser';
 import {DOCUMENT} from '@angular/common';
 import {ANIMATION_MODULE_TYPE, ApplicationRef, Inject, Injectable, NgZone, OnDestroy, Provider, RendererFactory2} from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
-
-import {BrowserAnimationBuilder} from './animation_builder';
 
 @Injectable()
 export class InjectableAnimationEngine extends AnimationEngine implements OnDestroy {


### PR DESCRIPTION
`AnimationBuilder` has no providers with `provideAnimationsAsync` because it was located in `@angular/plaform-browser/animations`. Since any import from `@angular/plaform-browser/animations` breaks the lazy-loading of the animation code, we have to move this class outside of it => to the animation package.

`@angular/plaform-browser/animations` will now import `BrowserAnimationBuilder` from `@angular/animations/browser` to maintain the compatibility.

Now, if you want to use an `AnimationBuilder` with `provideAnimationsAsync()`, please inject directly `BrowserAnimationBuilder`, it is now public and `providedIn:'root'`.

fixes #52096