### PR TITLE
refactor(forms): Unified Control State Change Events

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -29,6 +29,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     set asyncValidator(asyncValidatorFn: AsyncValidatorFn | null);
     clearAsyncValidators(): void;
     clearValidators(): void;
+    // (undocumented)
+    readonly controlStateChanges: Observable<ControlEvent<TValue>>;
     get dirty(): boolean;
     disable(opts?: {
         onlySelf?: boolean;

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -394,8 +394,8 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     this._forEachChild((control: AbstractControl, index: number) => {
       control.reset(value[index], {onlySelf: true, emitEvent: options.emitEvent});
     });
-    this._updatePristine(options);
-    this._updateTouched(options);
+    this._updatePristine(options, this);
+    this._updateTouched(options, this);
     this.updateValueAndValidity(options);
   }
 

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -490,8 +490,8 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
       control.reset(
           value ? (value as any)[name] : null, {onlySelf: true, emitEvent: options.emitEvent});
     });
-    this._updatePristine(options);
-    this._updateTouched(options);
+    this._updatePristine(options, this);
+    this._updateTouched(options, this);
     this.updateValueAndValidity(options);
   }
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -12,8 +12,10 @@ import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing'
 import {AbstractControl, AsyncValidator, AsyncValidatorFn, COMPOSITION_BUFFER_MODE, ControlValueAccessor, DefaultValueAccessor, FormArray, FormBuilder, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormsModule, MaxValidator, MinLengthValidator, MinValidator, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NG_VALUE_ACCESSOR, ReactiveFormsModule, Validator, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent, sortedClassList} from '@angular/platform-browser/testing/src/browser_util';
-import {merge, NEVER, of, Subscription, timer} from 'rxjs';
+import {merge, NEVER, of, Subject, Subscription, timer} from 'rxjs';
 import {map, tap} from 'rxjs/operators';
+
+import {ControlEvent} from '../src/model/abstract_model';
 
 import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
@@ -989,6 +991,236 @@ describe('reactive forms integration tests', () => {
 
          form.reset();
        });
+  });
+
+  describe('unified form state change', () => {
+    it('Single level Control should emit changes for itself', () => {
+      const fc = new FormControl<string|null>('foo', Validators.required);
+
+      const values: ControlEvent[] = [];
+      fc.controlStateChanges.subscribe(event => values.push(event));
+      expect(values.length).toBe(0);
+
+      fc.markAsTouched();
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'touched', value: 'touched'});
+      fc.markAsUntouched();
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'touched', value: 'untouched'});
+      fc.markAsDirty();
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'pristine', value: 'dirty'});
+      fc.markAsPristine();
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'pristine', value: 'pristine'});
+
+      fc.disable();
+      expect(values.at(-2)).toEqual({changedControl: fc, type: 'status', value: 'DISABLED'});
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'value', value: 'foo'});
+      expect(values.length).toBe(6);
+
+      fc.enable();
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'status', value: 'VALID'});
+      expect(values.at(-2)).toEqual({changedControl: fc, type: 'value', value: 'foo'});
+      expect(values.length).toBe(8);
+
+      fc.setValue(null);
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'status', value: 'INVALID'});
+      expect(values.at(-2)).toEqual({changedControl: fc, type: 'value', value: null});
+      expect(values.length).toBe(10);  // setValue doesnt emit dirty or touched
+
+      fc.setValue('bar');
+      expect(values.at(-2)).toEqual({changedControl: fc, type: 'value', value: 'bar'});
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'status', value: 'VALID'});
+      expect(values.length).toBe(12);
+
+      const subject = new Subject<string>();
+      const asyncValidator = () => subject.pipe(map(() => null));
+      fc.addAsyncValidators(asyncValidator);
+      fc.updateValueAndValidity();
+
+      // Value is emitted because of updateValueAndValidity
+      expect(values.at(-2)).toEqual({changedControl: fc, type: 'value', value: 'bar'});
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'status', value: 'PENDING'});
+      subject.next('');
+      subject.complete();
+      expect(values.at(-1)).toEqual({changedControl: fc, type: 'status', value: 'VALID'});
+      expect(values.length).toBe(15);
+    });
+
+    it('Nested formControl should emit changes for itself and its parent', () => {
+      const fc1 = new FormControl<string|null>('foo', Validators.required);
+      const fc2 = new FormControl<string|null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fc1Values: ControlEvent[] = [];
+      const fc2Values: ControlEvent[] = [];
+      const fgValues: ControlEvent[] = [];
+      fc1.controlStateChanges.subscribe(event => fc1Values.push(event));
+      fc2.controlStateChanges.subscribe(event => fc2Values.push(event));
+      fg.controlStateChanges.subscribe(event => fgValues.push(event));
+
+      fc1.setValue('bar');
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'VALID'});
+      expect(fc1Values.at(-2)).toEqual({changedControl: fc1, type: 'value', value: 'bar'});
+      expect(fc1Values.length).toBe(2);
+
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'VALID'});
+      expect(fgValues.at(-2))
+          .toEqual({changedControl: fc1, type: 'value', value: {fc1: 'bar', fc2: 'bar'}});
+      expect(fgValues.length).toBe(2);
+    });
+
+    it('Nested formControl should children as pristine as emit', () => {
+      const fc1 = new FormControl<string|null>('foo', Validators.required);
+      const fc2 = new FormControl<string|null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fc1Values: ControlEvent[] = [];
+      const fc2Values: ControlEvent[] = [];
+      const fgValues: ControlEvent[] = [];
+      fc1.controlStateChanges.subscribe(event => fc1Values.push(event));
+      fc2.controlStateChanges.subscribe(event => fc2Values.push(event));
+      fg.controlStateChanges.subscribe(event => fgValues.push(event));
+
+      fc1.setValue('bar');
+      expect(fc1Values.length).toBe(2);
+      expect(fgValues.length).toBe(2);
+
+      fg.markAsPristine();
+      expect(fgValues.at(-1)).toEqual({changedControl: fg, type: 'pristine', value: 'pristine'});
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'pristine', value: 'pristine'});
+      expect(fc2Values.at(-1)).toEqual({changedControl: fc2, type: 'pristine', value: 'pristine'});
+
+      expect(fc1Values.length).toBe(3);
+      expect(fc2Values.length).toBe(1);
+
+      // Marking children as pristine does not emit an event on the parent
+      expect(fgValues.length).toBe(3);
+    });
+
+    it('Nested formControl should emit dirty', () => {
+      const fc1 = new FormControl<string|null>('foo', Validators.required);
+      const fc2 = new FormControl<string|null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fc1Values: ControlEvent[] = [];
+      const fc2Values: ControlEvent[] = [];
+      const fgValues: ControlEvent[] = [];
+      fc1.controlStateChanges.subscribe(event => fc1Values.push(event));
+      fc2.controlStateChanges.subscribe(event => fc2Values.push(event));
+      fg.controlStateChanges.subscribe(event => fgValues.push(event));
+
+      fc1.markAsDirty();
+      expect(fc1Values.length).toBe(1);
+      expect(fgValues.length).toBe(1);
+      expect(fc2Values.length).toBe(0);
+
+      // changedControl is the child control
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'pristine', value: 'dirty'});
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'pristine', value: 'dirty'});
+    });
+
+    it('Nested formControl should emit touched', () => {
+      const fc1 = new FormControl<string|null>('foo', Validators.required);
+      const fc2 = new FormControl<string|null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fc1Values: ControlEvent[] = [];
+      const fc2Values: ControlEvent[] = [];
+      const fgValues: ControlEvent[] = [];
+      fc1.controlStateChanges.subscribe(event => fc1Values.push(event));
+      fc2.controlStateChanges.subscribe(event => fc2Values.push(event));
+      fg.controlStateChanges.subscribe(event => fgValues.push(event));
+
+      fc1.markAsTouched();
+      expect(fc1Values.length).toBe(1);
+      expect(fgValues.length).toBe(1);
+      expect(fc2Values.length).toBe(0);
+
+      // changedControl is the child control
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'touched', value: 'touched'});
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'touched', value: 'touched'});
+    });
+
+    it('Nested formControl should emit disabled', () => {
+      const fc1 = new FormControl<string|null>('foo', Validators.required);
+      const fc2 = new FormControl<string|null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fc1Values: ControlEvent[] = [];
+      const fc2Values: ControlEvent[] = [];
+      const fgValues: ControlEvent[] = [];
+      fc1.controlStateChanges.subscribe(event => fc1Values.push(event));
+      fc2.controlStateChanges.subscribe(event => fc2Values.push(event));
+      fg.controlStateChanges.subscribe(event => fgValues.push(event));
+
+      fc1.disable();
+      expect(fc1Values.length).toBe(2);
+      expect(fgValues.length).toBe(4);
+      expect(fc2Values.length).toBe(0);
+
+      expect(fgValues.at(-4)).toEqual({changedControl: fg, type: 'value', value: {fc2: 'bar'}});
+      expect(fgValues.at(-3)).toEqual({changedControl: fg, type: 'status', value: 'VALID'});
+
+      // TODO: Check if this is expected
+      expect(fgValues.at(-2)).toEqual({changedControl: fc1, type: 'pristine', value: 'pristine'});
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'touched', value: 'untouched'});
+
+      expect(fc1Values.at(-2)).toEqual({changedControl: fc1, type: 'status', value: 'DISABLED'});
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'value', value: 'foo'});
+    });
+
+    it('Nested formControl should emit PENDING', () => {
+      const fc1 = new FormControl<string|null>('foo', Validators.required);
+      const fc2 = new FormControl<string|null>('bar', Validators.required);
+      const fg = new FormGroup({fc1, fc2});
+
+      const fc1Values: ControlEvent[] = [];
+      const fc2Values: ControlEvent[] = [];
+      const fgValues: ControlEvent[] = [];
+      fc1.controlStateChanges.subscribe(event => fc1Values.push(event));
+      fc2.controlStateChanges.subscribe(event => fc2Values.push(event));
+      fg.controlStateChanges.subscribe(event => fgValues.push(event));
+
+      fc1.markAsPending();
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'PENDING'});
+
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'PENDING'});
+      expect(fc1Values.length).toBe(1);
+      expect(fgValues.length).toBe(1);
+      expect(fc2Values.length).toBe(0);
+
+
+      // Reseting to VALID
+      fc1.updateValueAndValidity();
+      expect(fgValues.at(-2))
+          .toEqual({changedControl: fc1, type: 'value', value: {fc1: 'foo', fc2: 'bar'}});
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'VALID'});
+
+      expect(fc1Values.at(-2)).toEqual({changedControl: fc1, type: 'value', value: 'foo'});
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'VALID'});
+      expect(fc1Values.length).toBe(3);
+      expect(fgValues.length).toBe(3);
+      expect(fc2Values.length).toBe(0);
+
+      // Triggering PENDING again with the async validator now
+      const subject = new Subject<string>();
+      const asyncValidator = () => subject.pipe(map(() => null));
+      fc1.addAsyncValidators(asyncValidator);
+      fc1.updateValueAndValidity();
+
+      expect(fc1Values.length).toBe(5);
+      expect(fgValues.length).toBe(5);
+      expect(fc2Values.length).toBe(0);
+
+      expect(fgValues.at(-2))
+          .toEqual({changedControl: fc1, type: 'value', value: {fc1: 'foo', fc2: 'bar'}});
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'PENDING'});
+      expect(fc1Values.at(-2)).toEqual({changedControl: fc1, type: 'value', value: 'foo'});
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'PENDING'});
+
+      subject.next('');
+      subject.complete();
+      expect(fgValues.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'VALID'});
+      expect(fc1Values.at(-1)).toEqual({changedControl: fc1, type: 'status', value: 'VALID'});
+    });
   });
 
   describe('setting status classes', () => {


### PR DESCRIPTION
This commit adds a global observable to subscribe to track changes around any `AbstractControl` (its children).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
