### PR TITLE
FormArray directive

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -279,6 +279,22 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
 }
 
 // @public
+export class FormArrayDirective extends AbstractFormDirective<FormArray> implements OnChanges, OnDestroy {
+    constructor(validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], callSetDisabledState?: SetDisabledStateOption);
+    form: FormArray;
+    // (undocumented)
+    ngOnChanges(changes: SimpleChanges): void;
+    // (undocumented)
+    ngOnDestroy(): void;
+    ngSubmit: EventEmitter<any>;
+    onSubmit($event: Event): boolean;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<FormArrayDirective, "[formArray]", ["ngForm"], { "form": { "alias": "formArray"; "required": false; }; }, { "ngSubmit": "ngSubmit"; }, never, never, false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<FormArrayDirective, [{ optional: true; self: true; }, { optional: true; self: true; }, { optional: true; }]>;
+}
+
+// @public
 export class FormArrayName extends ControlContainer implements OnInit, OnDestroy {
     constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[]);
     get control(): FormArray;
@@ -481,32 +497,15 @@ export class FormGroup<TControl extends {
 }
 
 // @public
-export class FormGroupDirective extends ControlContainer implements Form, OnChanges, OnDestroy {
-    constructor(validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], callSetDisabledState?: SetDisabledStateOption | undefined);
-    addControl(dir: FormControlName): FormControl;
-    addFormArray(dir: FormArrayName): void;
-    addFormGroup(dir: FormGroupName): void;
-    get control(): FormGroup;
-    directives: FormControlName[];
+export class FormGroupDirective extends AbstractFormDirective<FormGroup> implements OnChanges, OnDestroy {
+    constructor(validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], callSetDisabledState?: SetDisabledStateOption);
     form: FormGroup;
-    get formDirective(): Form;
-    getControl(dir: FormControlName): FormControl;
-    getFormArray(dir: FormArrayName): FormArray;
-    getFormGroup(dir: FormGroupName): FormGroup;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): void;
     ngSubmit: EventEmitter<any>;
-    onReset(): void;
     onSubmit($event: Event): boolean;
-    get path(): string[];
-    removeControl(dir: FormControlName): void;
-    removeFormArray(dir: FormArrayName): void;
-    removeFormGroup(dir: FormGroupName): void;
-    resetForm(value?: any): void;
-    readonly submitted: boolean;
-    updateModel(dir: FormControlName, value: any): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<FormGroupDirective, "[formGroup]", ["ngForm"], { "form": { "alias": "formGroup"; "required": false; }; }, { "ngSubmit": "ngSubmit"; }, never, never, false, never>;
     // (undocumented)
@@ -851,7 +850,7 @@ export class ReactiveFormsModule {
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<ReactiveFormsModule>;
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ReactiveFormsModule, [typeof i5_2.FormControlDirective, typeof i6_2.FormGroupDirective, typeof i7_2.FormControlName, typeof i8_2.FormGroupName, typeof i8_2.FormArrayName], never, [typeof i4_2.ɵInternalFormsSharedModule, typeof i5_2.FormControlDirective, typeof i6_2.FormGroupDirective, typeof i7_2.FormControlName, typeof i8_2.FormGroupName, typeof i8_2.FormArrayName]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ReactiveFormsModule, [typeof i5_2.FormControlDirective, typeof i6_2.FormGroupDirective, typeof i7_2.FormArrayDirective, typeof i8_2.FormControlName, typeof i9_2.FormGroupName, typeof i9_2.FormArrayName], never, [typeof i4_2.ɵInternalFormsSharedModule, typeof i5_2.FormControlDirective, typeof i6_2.FormGroupDirective, typeof i7_2.FormArrayDirective, typeof i8_2.FormControlName, typeof i9_2.FormGroupName, typeof i9_2.FormArrayName]>;
 }
 
 // @public

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -18,6 +18,7 @@ import {NgNoValidate} from './directives/ng_no_validate_directive';
 import {NumberValueAccessor} from './directives/number_value_accessor';
 import {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 import {RangeValueAccessor} from './directives/range_value_accessor';
+import {FormArrayDirective} from './directives/reactive_directives/form_array_directive';
 import {FormControlDirective} from './directives/reactive_directives/form_control_directive';
 import {FormControlName} from './directives/reactive_directives/form_control_name';
 import {FormGroupDirective} from './directives/reactive_directives/form_group_directive';
@@ -52,6 +53,7 @@ export {NgModelGroup} from './directives/ng_model_group';
 export {NumberValueAccessor} from './directives/number_value_accessor';
 export {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 export {RangeValueAccessor} from './directives/range_value_accessor';
+export {FormArrayDirective} from './directives/reactive_directives/form_array_directive';
 export {
   FormControlDirective,
   NG_MODEL_WITH_FORM_CONTROL_WARNING,
@@ -97,6 +99,7 @@ export const TEMPLATE_DRIVEN_DIRECTIVES: Type<any>[] = [NgModel, NgModelGroup, N
 export const REACTIVE_DRIVEN_DIRECTIVES: Type<any>[] = [
   FormControlDirective,
   FormGroupDirective,
+  FormArrayDirective,
   FormControlName,
   FormGroupName,
   FormArrayName,

--- a/packages/forms/src/directives/ng_control_status.ts
+++ b/packages/forms/src/directives/ng_control_status.ts
@@ -119,7 +119,7 @@ export class NgControlStatus extends AbstractControlStatus {
  */
 @Directive({
   selector:
-    '[formGroupName],[formArrayName],[ngModelGroup],[formGroup],form:not([ngNoForm]),[ngForm]',
+    '[formGroupName],[formArrayName],[ngModelGroup],[formGroup],[formArray],form:not([ngNoForm]),[ngForm]',
   host: ngGroupStatusHost,
 })
 export class NgControlStatusGroup extends AbstractControlStatus {

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -115,7 +115,7 @@ const resolvedPromise = (() => Promise.resolve())();
  * @publicApi
  */
 @Directive({
-  selector: 'form:not([ngNoForm]):not([formGroup]),ng-form,[ngForm]',
+  selector: 'form:not([ngNoForm]):not([formGroup]):not([formArray]),ng-form,[ngForm]',
   providers: [formDirectiveProvider],
   host: {'(submit)': 'onSubmit($event)', '(reset)': 'onReset()'},
   outputs: ['ngSubmit'],

--- a/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
+++ b/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
@@ -1,0 +1,392 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  Directive,
+  EventEmitter,
+  Inject,
+  Injectable,
+  OnChanges,
+  OnDestroy,
+  Optional,
+  Self,
+  SimpleChanges,
+} from '@angular/core';
+
+import {
+  AbstractControl,
+  FormGroup,
+  FormResetEvent,
+  FormSubmittedEvent,
+  NG_ASYNC_VALIDATORS,
+  NG_VALIDATORS,
+} from '../../forms';
+import {FormArray} from '../../model/form_array';
+import {FormControl, isFormControl} from '../../model/form_control';
+import {ControlContainer} from '../control_container';
+import {Form} from '../form_interface';
+import {missingFormException} from '../reactive_errors';
+import {
+  CALL_SET_DISABLED_STATE,
+  cleanUpControl,
+  cleanUpFormContainer,
+  cleanUpValidators,
+  removeListItem,
+  SetDisabledStateOption,
+  setUpControl,
+  setUpFormContainer,
+  setUpValidators,
+  syncPendingControls,
+} from '../shared';
+import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
+
+import {FormControlName} from './form_control_name';
+import {FormArrayName, FormGroupName} from './form_group_name';
+
+/**
+ * @description
+ *
+ * Abstract class for the form directives (FormArrayDirective, FormGroupDirective) who bind an
+ * existing `Form` to a DOM element.
+ *
+ * @publicApi
+ */
+
+@Injectable()
+export abstract class AbstractFormDirective<T extends AbstractControl>
+  extends ControlContainer
+  implements Form, OnChanges, OnDestroy
+{
+  /**
+   * @description
+   * Reports whether the form submission has been triggered.
+   */
+  public readonly submitted: boolean = false;
+
+  /**
+   * Reference to an old form group input value, which is needed to cleanup old instance in case it
+   * was replaced with a new one.
+   */
+  private _oldForm: T | undefined;
+
+  /**
+   * Callback that should be invoked when controls in FormArray or FormArray collection change
+   * (added or removed). This callback triggers corresponding DOM updates.
+   *
+   * @internal
+   */
+  readonly _onCollectionChange = () => this._updateDomValue();
+
+  /**
+   * @description
+   * Tracks the list of added `FormControlName` instances
+   */
+  directives: FormControlName[] = [];
+
+  /**
+   * @description
+   * Tracks the form bound to this directive.
+   */
+  public form: T = null!;
+
+  /**
+   * @description
+   * Emits an event when the form submission has been triggered.
+   */
+  abstract ngSubmit: EventEmitter<any>;
+
+  constructor(
+    @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator | ValidatorFn)[],
+    @Optional()
+    @Self()
+    @Inject(NG_ASYNC_VALIDATORS)
+    asyncValidators: (AsyncValidator | AsyncValidatorFn)[],
+    @Optional()
+    @Inject(CALL_SET_DISABLED_STATE)
+    private callSetDisabledState?: SetDisabledStateOption,
+  ) {
+    super();
+    this._setValidators(validators);
+    this._setAsyncValidators(asyncValidators);
+  }
+
+  /** @nodoc */
+  ngOnChanges(changes: SimpleChanges): void {
+    this.onChanges(changes);
+  }
+
+  /** @nodoc */
+  ngOnDestroy() {
+    this.onDestroy();
+  }
+
+  /** @nodoc */
+  protected onChanges(changes: SimpleChanges): void {
+    this._checkFormPresent();
+    if (changes.hasOwnProperty('form')) {
+      this._updateValidators();
+      this._updateDomValue();
+      this._updateRegistrations();
+      this._oldForm = this.form;
+    }
+  }
+
+  /** @nodoc */
+  protected onDestroy() {
+    if (this.form) {
+      cleanUpValidators(this.form, this);
+
+      // Currently the `onCollectionChange` callback is rewritten each time the
+      // `_registerOnCollectionChange` function is invoked. The implication is that cleanup should
+      // happen *only* when the `onCollectionChange` callback was set by this directive instance.
+      // Otherwise it might cause overriding a callback of some other directive instances. We should
+      // consider updating this logic later to make it similar to how `onChange` callbacks are
+      // handled, see https://github.com/angular/angular/issues/39732 for additional info.
+      if (this.form._onCollectionChange === this._onCollectionChange) {
+        this.form._registerOnCollectionChange(() => {});
+      }
+    }
+  }
+
+  /**
+   * @description
+   * Returns this directive's instance.
+   */
+  override get formDirective(): Form {
+    return this;
+  }
+
+  /**
+   * @description
+   * Returns the Form bound to this directive.
+   */
+  override get control(): T {
+    return this.form;
+  }
+
+  /**
+   * @description
+   * Returns an array representing the path to this group. Because this directive
+   * always lives at the top level of a form, it always an empty array.
+   */
+  override get path(): string[] {
+    return [];
+  }
+
+  /**
+   * @description
+   * Method that sets up the control directive in this group, re-calculates its value
+   * and validity, and adds the instance to the internal list of directives.
+   *
+   * @param dir The `FormControlName` directive instance.
+   */
+  addControl(dir: FormControlName): FormControl {
+    const ctrl: any = this.form.get(dir.path);
+    setUpControl(ctrl, dir, this.callSetDisabledState);
+    ctrl.updateValueAndValidity({emitEvent: false});
+    this.directives.push(dir);
+    return ctrl;
+  }
+
+  /**
+   * @description
+   * Retrieves the `FormControl` instance from the provided `FormControlName` directive
+   *
+   * @param dir The `FormControlName` directive instance.
+   */
+  getControl(dir: FormControlName): FormControl {
+    return <FormControl>this.form.get(dir.path);
+  }
+
+  /**
+   * @description
+   * Removes the `FormControlName` instance from the internal list of directives
+   *
+   * @param dir The `FormControlName` directive instance.
+   */
+  removeControl(dir: FormControlName): void {
+    cleanUpControl(dir.control || null, dir, /* validateControlPresenceOnChange */ false);
+    removeListItem(this.directives, dir);
+  }
+
+  /**
+   * Adds a new `FormGroupName` directive instance to the form.
+   *
+   * @param dir The `FormGroupName` directive instance.
+   */
+  addFormGroup(dir: FormGroupName): void {
+    this._setUpFormContainer(dir);
+  }
+
+  /**
+   * Performs the necessary cleanup when a `FormGroupName` directive instance is removed from the
+   * view.
+   *
+   * @param dir The `FormGroupName` directive instance.
+   */
+  removeFormGroup(dir: FormGroupName): void {
+    this._cleanUpFormContainer(dir);
+  }
+
+  /**
+   * @description
+   * Retrieves the `FormGroup` for a provided `FormGroupName` directive instance
+   *
+   * @param dir The `FormGroupName` directive instance.
+   */
+  getFormGroup(dir: FormGroupName): FormGroup {
+    return <FormGroup>this.form.get(dir.path);
+  }
+
+  /**
+   * @description
+   * Retrieves the `FormArray` for a provided `FormArrayName` directive instance.
+   *
+   * @param dir The `FormArrayName` directive instance.
+   */
+  getFormArray(dir: FormArrayName): FormArray {
+    return <FormArray>this.form.get(dir.path);
+  }
+
+  /**
+   * Performs the necessary setup when a `FormArrayName` directive instance is added to the view.
+   *
+   * @param dir The `FormArrayName` directive instance.
+   */
+  addFormArray(dir: FormArrayName): void {
+    this._setUpFormContainer(dir);
+  }
+
+  /**
+   * Performs the necessary cleanup when a `FormArrayName` directive instance is removed from the
+   * view.
+   *
+   * @param dir The `FormArrayName` directive instance.
+   */
+  removeFormArray(dir: FormArrayName): void {
+    this._cleanUpFormContainer(dir);
+  }
+
+  /**
+   * Sets the new value for the provided `FormControlName` directive.
+   *
+   * @param dir The `FormControlName` directive instance.
+   * @param value The new value for the directive's control.
+   */
+  updateModel(dir: FormControlName, value: any): void {
+    const ctrl = <FormControl>this.form.get(dir.path);
+    ctrl.setValue(value);
+  }
+
+  /**
+   * @description
+   * Method called when the "reset" event is triggered on the form.
+   */
+  onReset(): void {
+    this.resetForm();
+  }
+
+  /**
+   * @description
+   * Resets the form to an initial value and resets its submitted status.
+   *
+   * @param value The new value for the form.
+   */
+  resetForm(value: any = undefined): void {
+    this.form.reset(value);
+    (this as {submitted: boolean}).submitted = false;
+    this.form._events.next(new FormResetEvent(this.form));
+  }
+
+  /**
+   * @description
+   * Method called with the "submit" event is triggered on the form.
+   * Triggers the `ngSubmit` emitter to emit the "submit" event as its payload.
+   *
+   * @param $event The "submit" event object
+   */
+  onSubmit($event: Event): boolean {
+    (this as {submitted: boolean}).submitted = true;
+    syncPendingControls(this.form, this.directives);
+    this.ngSubmit.emit($event);
+    this.form._events.next(new FormSubmittedEvent(this.control));
+
+    // Forms with `method="dialog"` have some special behavior that won't reload the page and that
+    // shouldn't be prevented. Note that we need to null check the `event` and the `target`, because
+    // some internal apps call this method directly with the wrong arguments.
+    return ($event?.target as HTMLFormElement | null)?.method === 'dialog';
+  }
+
+  /** @internal */
+  _updateDomValue() {
+    this.directives.forEach((dir) => {
+      const oldCtrl = dir.control;
+      const newCtrl = this.form.get(dir.path);
+      if (oldCtrl !== newCtrl) {
+        // Note: the value of the `dir.control` may not be defined, for example when it's a first
+        // `FormControl` that is added to a `FormGroup` instance (via `addControl` call).
+        cleanUpControl(oldCtrl || null, dir);
+
+        // Check whether new control at the same location inside the corresponding `FormGroup` is an
+        // instance of `FormControl` and perform control setup only if that's the case.
+        // Note: we don't need to clear the list of directives (`this.directives`) here, it would be
+        // taken care of in the `removeControl` method invoked when corresponding `formControlName`
+        // directive instance is being removed (invoked from `FormControlName.ngOnDestroy`).
+        if (isFormControl(newCtrl)) {
+          setUpControl(newCtrl, dir, this.callSetDisabledState);
+          (dir as {control: FormControl}).control = newCtrl;
+        }
+      }
+    });
+
+    this.form._updateTreeValidity({emitEvent: false});
+  }
+
+  private _setUpFormContainer(dir: FormArrayName | FormGroupName): void {
+    const ctrl: any = this.form.get(dir.path);
+    setUpFormContainer(ctrl, dir);
+    // NOTE: this operation looks unnecessary in case no new validators were added in
+    // `setUpFormContainer` call. Consider updating this code to match the logic in
+    // `_cleanUpFormContainer` function.
+    ctrl.updateValueAndValidity({emitEvent: false});
+  }
+
+  private _cleanUpFormContainer(dir: FormArrayName | FormGroupName): void {
+    if (this.form) {
+      const ctrl: any = this.form.get(dir.path);
+      if (ctrl) {
+        const isControlUpdated = cleanUpFormContainer(ctrl, dir);
+        if (isControlUpdated) {
+          // Run validity check only in case a control was updated (i.e. view validators were
+          // removed) as removing view validators might cause validity to change.
+          ctrl.updateValueAndValidity({emitEvent: false});
+        }
+      }
+    }
+  }
+
+  private _updateRegistrations() {
+    this.form._registerOnCollectionChange(this._onCollectionChange);
+    if (this._oldForm) {
+      this._oldForm._registerOnCollectionChange(() => {});
+    }
+  }
+
+  private _updateValidators() {
+    setUpValidators(this.form, this);
+    if (this._oldForm) {
+      cleanUpValidators(this._oldForm, this);
+    }
+  }
+
+  private _checkFormPresent() {
+    if (!this.form && (typeof ngDevMode === 'undefined' || ngDevMode)) {
+      throw missingFormException();
+    }
+  }
+}

--- a/packages/forms/src/directives/reactive_directives/form_array_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_array_directive.ts
@@ -8,33 +8,33 @@
 
 import {Directive, EventEmitter, forwardRef, Input, Output, Provider} from '@angular/core';
 
-import {FormGroup} from '../../model/form_group';
+import {FormArray} from '../../model/form_array';
 import {ControlContainer} from '../control_container';
 
 import {AbstractFormDirective} from './abstract_form.directive';
 
 const formDirectiveProvider: Provider = {
   provide: ControlContainer,
-  useExisting: forwardRef(() => FormGroupDirective),
+  useExisting: forwardRef(() => FormArrayDirective),
 };
 
 /**
  * @description
  *
- * Binds an existing `FormGroup` or `FormRecord` to a DOM element.
+ * Binds an existing `FormArray` to a DOM element.
  *
- * This directive accepts an existing `FormGroup` instance. It will then use this
- * `FormGroup` instance to match any child `FormControl`, `FormGroup`/`FormRecord`,
+ * This directive accepts an existing `FormArray` instance. It will then use this
+ * `FormArray` instance to match any child `FormControl`, `FormGroup`/`FormRecord`,
  * and `FormArray` instances to child `FormControlName`, `FormGroupName`,
  * and `FormArrayName` directives.
  *
- * @see [Reactive Forms Guide](guide/forms/reactive-forms)
+ * @see [Reactive Forms Guide](guide/reactive-forms)
  * @see {@link AbstractControl}
  *
  * @usageNotes
  * ### Register Form Group
  *
- * The following example registers a `FormGroup` with first name and last name controls,
+ * The following example registers a `FormArray` with first name and last name controls,
  * and listens for the *ngSubmit* event when the button is clicked.
  *
  * {@example forms/ts/simpleFormGroup/simple_form_group_example.ts region='Component'}
@@ -43,17 +43,17 @@ const formDirectiveProvider: Provider = {
  * @publicApi
  */
 @Directive({
-  selector: '[formGroup]',
+  selector: '[formArray]',
   providers: [formDirectiveProvider],
   host: {'(submit)': 'onSubmit($event)', '(reset)': 'onReset()'},
   exportAs: 'ngForm',
 })
-export class FormGroupDirective extends AbstractFormDirective<FormGroup> {
+export class FormArrayDirective extends AbstractFormDirective<FormArray> {
   /**
    * @description
-   * Tracks the `FormGroup` bound to this directive.
+   * Tracks the `FormArray` bound to this directive.
    */
-  @Input('formGroup') override form: FormGroup = null!;
+  @Input('formArray') override form: FormArray = null!;
 
   /**
    * @description

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -38,6 +38,7 @@ import {
 import {_ngModelWarning, controlPath, isPropertyUpdated, selectValueAccessor} from '../shared';
 import {AsyncValidator, AsyncValidatorFn, Validator, ValidatorFn} from '../validators';
 
+import {FormArrayDirective} from './form_array_directive';
 import {NG_MODEL_WITH_FORM_CONTROL_WARNING} from './form_control_directive';
 import {FormGroupDirective} from './form_group_directive';
 import {FormArrayName, FormGroupName} from './form_group_name';
@@ -219,6 +220,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
       } else if (
         !(this._parent instanceof FormGroupName) &&
         !(this._parent instanceof FormGroupDirective) &&
+        !(this._parent instanceof FormArrayDirective) &&
         !(this._parent instanceof FormArrayName)
       ) {
         throw controlParentException(this.name);

--- a/packages/forms/src/directives/reactive_errors.ts
+++ b/packages/forms/src/directives/reactive_errors.ts
@@ -20,8 +20,8 @@ import {
 export function controlParentException(nameOrIndex: string | number | null): Error {
   return new RuntimeError(
     RuntimeErrorCode.FORM_CONTROL_NAME_MISSING_PARENT,
-    `formControlName must be used with a parent formGroup directive. You'll want to add a formGroup
-      directive and pass it an existing FormGroup instance (you can create one in your class).
+    `formControlName must be used with a parent formGroup or formArray directive.  You'll want to add a formGroup/formArray
+      directive and pass it an existing FormGroup/FormArray instance (you can create one in your class).
 
       ${describeFormControl(nameOrIndex)}
 

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -368,7 +368,7 @@ export function isBuiltInAccessor(valueAccessor: ControlValueAccessor): boolean 
 }
 
 export function syncPendingControls(
-  form: FormGroup,
+  form: AbstractControl,
   directives: Set<NgControl> | NgControl[],
 ): void {
   form._syncPendingControls();

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -34,6 +34,7 @@ export {ɵNgNoValidate} from './directives/ng_no_validate_directive';
 export {NumberValueAccessor} from './directives/number_value_accessor';
 export {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 export {RangeValueAccessor} from './directives/range_value_accessor';
+export {FormArrayDirective} from './directives/reactive_directives/form_array_directive';
 export {FormControlDirective} from './directives/reactive_directives/form_control_directive';
 export {FormControlName} from './directives/reactive_directives/form_control_name';
 export {FormGroupDirective} from './directives/reactive_directives/form_group_directive';


### PR DESCRIPTION
The `FormArrayDirective` will allow to have a `FormArray` as a top-level form object.

* `NgControlStatusGroup` directive will be applied to  `FormArrayDirective` 
* `NgForm` will still create a `FormGroup`

Fixes https://github.com/angular/angular/issues/30264
